### PR TITLE
Issue/1 - Introduce Fetch middleware support

### DIFF
--- a/app/middlewares/fetch/cacheMiddleware.js
+++ b/app/middlewares/fetch/cacheMiddleware.js
@@ -1,0 +1,38 @@
+import md5 from 'crypto-js/md5'
+
+const processing = {}
+
+export default ( options, next ) => {
+	// Make a cache key from the path.
+	const cacheKey = `nicholas-${md5( options.path )}`
+
+	// If this item should not be cached, add it to the list of items being processed and move on.
+	if ( !options.cacheItem || true !== options.cacheItem ) {
+		return next( options )
+	}
+
+	const item = window.sessionStorage.getItem( cacheKey )
+
+	// If the item could not be found, save it in session storage and fetch.
+	if ( null === item ) {
+
+		// Check to see if this item is currently being loaded. If-so, force this to wait for that request, instead.
+		// This prevents multiples of the same request from being ran.
+		if ( undefined !== processing[cacheKey] ) {
+			return processing[cacheKey]
+		}
+
+		// Otherwise, store this in the processing queue, store it in sessionStorage, and clear the results.
+		processing[cacheKey] = next( options ).then( result => {
+			window.sessionStorage.setItem( cacheKey, JSON.stringify( result ) )
+			delete processing[cacheKey]
+
+			return result
+		} )
+
+		return processing[cacheKey]
+	}
+
+	// Otherwise, resolve the promise early, using the data stored in sessionStorage
+	return Promise.resolve( JSON.parse( item ) )
+}

--- a/middlewares.js
+++ b/middlewares.js
@@ -3,6 +3,7 @@ import validateAdminPage from './app/middlewares/route/validateAdminPage'
 import validateCompatibilityMode from './app/middlewares/route/validateCompatibilityMode'
 import primeCache from './app/middlewares/route/primeCache'
 import setPreloadWorker from './app/middlewares/setup/setPreloadWorker'
+import fetchCacheMiddleware from './app/middlewares/fetch/cacheMiddleware'
 
 // This should be compiled and exported as a global object.
 export {
@@ -10,5 +11,6 @@ export {
 	validateAdminPage,
 	validateCompatibilityMode,
 	primeCache,
-	setPreloadWorker
+	setPreloadWorker,
+	fetchCacheMiddleware
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Alex Standiford",
   "license": "MIT",
   "dependencies": {
-    "@wordpress/element": "^4.0.0"
+    "@wordpress/element": "^4.0.0",
+    "crypto-js": "^4.1.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@ registerPlugin( 'theme', { render: () => <CompatibilityModeToggle/> } );
 
 ## WordPress-specific Nicholas Router Middlewares
 
-[Nicholas Router]() supports adding middleware to routes. This package includes a couple handy middlewares to help with
+[Nicholas Router](https://github.com/nicholas-wordpress/router) supports adding middleware to routes. This package includes a couple handy middlewares to help with
 routing in a WordPress environment, including:
 
 1. Middleware to update the "edit post" in the admin bar
@@ -95,3 +95,28 @@ import {updateAdminBar, validateAdminPage, validateCompatibilityMode, primeCache
 		updateAdminBar
 	)
 ```
+
+## API Fetch Router Middleware
+
+This system also exports an instance of the [WordPress API Fetch]() library. This includes a way to set up middleware for this instance. This can be set up
+to automatically cache specicic REST endpoints using the cache middleware.
+
+```js
+import fetch from 'nicholas-wp'
+import { fetchCacheMiddleware } from 'nicholas-wp/middlewares'
+
+
+// Set up additional fetch cache middlewares.
+fetch.use( fetchCacheMiddleware )
+```
+
+From there, if you make any fetch calls and set `cacheItem` to `true` in your options, it will automatically cache that item using Nicholas. This data will
+be cleared in the same fashion as the core Nicholas router, and any concurrent requests will use the same request. This reduces the number of requests to 1 single request per route, and any call after that will instead load from the cache.
+
+```js
+// Fetch an item
+const result = await fetch({path: 'path/to/endpoint', cacheItem: true})
+const identicalResult = await fetch({path: 'path/to/endpoint', cacheItem: true})
+```
+
+The above example would make **one** REST request, and both items would return the same result as soon as that first request is resolved.


### PR DESCRIPTION
This PR makes it possible to add middleware to fetch that will automatically retrieve a specified request _one time_ instead of multiple times. It will also store the result in session storage. This is nice for situations where you're looping through content and intend to fetch data as you go.

For example, let's say you have a list of posts, and need to fetch the author data from each post in the list. Many of those posts may have the same author. Normally, fetch would loop through and make a request for each item in the loop, but with this middleware, it will only run _unique_ requests. This cuts back on the requests made in a loop, and also stores these items in session storage so they are not requested again in the session.

Finally, this is using the [Nicholas router](https://github.com/nicholas-wordpress/router)'s naming convention for cache keys, and because of this, this data will be cleared in the same fashion as the rest of the cached data. In-other words, it will be cleared whenever a post is updated, if the content is manually flushed, or if the theme extends when the cache needs flushed.